### PR TITLE
[Setup] Update requirements.txt to include necessary

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,290 +1,45 @@
-aiodns==3.0.0
-aiofile==3.7.4
-aiohttp==3.8.1
-aiosignal==1.2.0
-alabaster @ file:///home/ktietz/src/ci/alabaster_1611921544520/work
-anaconda-client==1.7.2
-anaconda-project @ file:///tmp/build/80754af9/anaconda-project_1610472525955/work
-anyio @ file:///tmp/build/80754af9/anyio_1617783275907/work/dist
-appdirs==1.4.4
-argh==0.26.2
-argon2-cffi @ file:///tmp/build/80754af9/argon2-cffi_1613037097816/work
-asn1crypto @ file:///tmp/build/80754af9/asn1crypto_1596577642040/work
-astroid @ file:///tmp/build/80754af9/astroid_1613500854201/work
-astropy @ file:///tmp/build/80754af9/astropy_1617745353437/work
-async-generator @ file:///home/ktietz/src/ci/async_generator_1611927993394/work
-async-timeout==4.0.2
-atomicwrites==1.4.0
-attrs @ file:///tmp/build/80754af9/attrs_1604765588209/work
-autopep8 @ file:///tmp/build/80754af9/autopep8_1615918855173/work
-backcall @ file:///home/ktietz/src/ci/backcall_1611930011877/work
-backports.shutil-get-terminal-size @ file:///tmp/build/80754af9/backports.shutil_get_terminal_size_1608222128777/work
-beautifulsoup4==4.9.1
-bibtexparser==1.1.0
-bitarray @ file:///tmp/build/80754af9/bitarray_1618431750766/work
-bkcharts==0.2
-black==20.8b1
-bleach @ file:///tmp/build/80754af9/bleach_1612211392645/work
-bokeh @ file:///tmp/build/80754af9/bokeh_1617824541184/work
-bootstrapped==0.0.2
-boto==2.49.0
-botocore @ file:///home/conda/feedstock_root/build_artifacts/botocore_1628669348048/work
-Bottleneck==1.3.2
-Brotli @ file:///tmp/build/80754af9/brotli-split_1602517619121/work
-brotlipy==0.7.0
-cachetools==4.1.1
-caio==0.9.3
-certifi==2021.10.8
-cffi @ file:///tmp/build/80754af9/cffi_1613246945912/work
-chardet @ file:///tmp/build/80754af9/chardet_1607706746162/work
-charset-normalizer @ file:///tmp/build/80754af9/charset-normalizer_1630003229654/work
-click @ file:///home/linux1/recipes/ci/click_1610990599742/work
-cloudpickle @ file:///tmp/build/80754af9/cloudpickle_1598884132938/work
-clyent==1.2.2
-colorama==0.4.3
-contextlib2==0.6.0.post1
-cryptography @ file:///tmp/build/80754af9/cryptography_1616769286105/work
-cycler==0.10.0
-Cython @ file:///tmp/build/80754af9/cython_1618435160151/work
-cytoolz==0.11.0
-dash @ file:///home/conda/feedstock_root/build_artifacts/dash_1618036125020/work
-dash-core-components @ file:///home/conda/feedstock_root/build_artifacts/dash-core-components_1617984947808/work
-dash-html-components @ file:///home/conda/feedstock_root/build_artifacts/dash-html-components_1617985450943/work
-dash-renderer @ file:///tmp/build/80754af9/dash-renderer_1617916866331/work
-dash-table @ file:///home/conda/feedstock_root/build_artifacts/dash-table_1617984959581/work
-dask @ file:///tmp/build/80754af9/dask-core_1617390489108/work
-decorator @ file:///tmp/build/80754af9/decorator_1617916966915/work
-defusedxml @ file:///tmp/build/80754af9/defusedxml_1615228127516/work
-diff-match-patch @ file:///tmp/build/80754af9/diff-match-patch_1594828741838/work
-distributed @ file:///tmp/build/80754af9/distributed_1617381497899/work
-docutils @ file:///home/conda/feedstock_root/build_artifacts/docutils_1620114299208/work
-dtrx==8.0.2
-entrypoints==0.3
-et-xmlfile==1.0.1
-fastcache==1.1.0
-feather-format @ file:///home/conda/feedstock_root/build_artifacts/feather-format_1588949071708/work
-filelock @ file:///home/linux1/recipes/ci/filelock_1610993975404/work
-fire==0.3.1
-flake8 @ file:///tmp/build/80754af9/flake8_1615834841867/work
-Flask @ file:///home/ktietz/src/ci/flask_1611932660458/work
-Flask-Compress @ file:///tmp/build/80754af9/flask-compress_1613587450386/work
-frozenlist==1.3.0
-fsspec @ file:///tmp/build/80754af9/fsspec_1617959894824/work
-future==0.18.2
-gevent @ file:///tmp/build/80754af9/gevent_1616770671827/work
-glob2 @ file:///home/linux1/recipes/ci/glob2_1610991677669/work
-gmpy2==2.0.8
-gql @ file:///home/conda/feedstock_root/build_artifacts/gql_1589765773339/work
-graphql-core @ file:///home/conda/feedstock_root/build_artifacts/graphql-core_1589761850168/work
-greenlet @ file:///tmp/build/80754af9/greenlet_1611957705398/work
-h5py==2.10.0
-HeapDict==1.0.1
-html5lib @ file:///tmp/build/80754af9/html5lib_1593446221756/work
-idna @ file:///home/linux1/recipes/ci/idna_1610986105248/work
-imageio @ file:///tmp/build/80754af9/imageio_1617700267927/work
-imagesize @ file:///home/ktietz/src/ci/imagesize_1611921604382/work
-importlib-metadata @ file:///tmp/build/80754af9/importlib-metadata_1617874469820/work
-iniconfig @ file:///home/linux1/recipes/ci/iniconfig_1610983019677/work
-intervaltree @ file:///tmp/build/80754af9/intervaltree_1598376443606/work
-ipykernel @ file:///tmp/build/80754af9/ipykernel_1596207638929/work/dist/ipykernel-5.3.4-py3-none-any.whl
-ipython @ file:///tmp/build/80754af9/ipython_1617120885885/work
-ipython-genutils @ file:///tmp/build/80754af9/ipython_genutils_1606773439826/work
-ipywidgets @ file:///tmp/build/80754af9/ipywidgets_1610481889018/work
-isort @ file:///tmp/build/80754af9/isort_1616355431277/work
-itsdangerous @ file:///home/ktietz/src/ci/itsdangerous_1611932585308/work
-jdcal==1.4.1
-jedi @ file:///tmp/build/80754af9/jedi_1592841866100/work
-jeepney @ file:///tmp/build/80754af9/jeepney_1606148855031/work
-Jinja2 @ file:///tmp/build/80754af9/jinja2_1612213139570/work
-jmespath @ file:///home/conda/feedstock_root/build_artifacts/jmespath_1589369830981/work
-joblib @ file:///tmp/build/80754af9/joblib_1613502643832/work
-json5==0.9.5
-jsonschema @ file:///tmp/build/80754af9/jsonschema_1602607155483/work
-jupyter==1.0.0
-jupyter-client @ file:///tmp/build/80754af9/jupyter_client_1616770841739/work
-jupyter-console @ file:///tmp/build/80754af9/jupyter_console_1616615302928/work
-jupyter-core @ file:///tmp/build/80754af9/jupyter_core_1612213311222/work
-jupyter-packaging @ file:///tmp/build/80754af9/jupyter-packaging_1613502826984/work
-jupyter-server @ file:///tmp/build/80754af9/jupyter_server_1616083640759/work
-jupyterlab @ file:///tmp/build/80754af9/jupyterlab_1619133235951/work
-jupyterlab-pygments @ file:///tmp/build/80754af9/jupyterlab_pygments_1601490720602/work
-jupyterlab-server @ file:///tmp/build/80754af9/jupyterlab_server_1617134334258/work
-jupyterlab-widgets @ file:///tmp/build/80754af9/jupyterlab_widgets_1609884341231/work
-keyring @ file:///tmp/build/80754af9/keyring_1614616740399/work
-kiwisolver @ file:///tmp/build/80754af9/kiwisolver_1612282420641/work
-lazy-object-proxy @ file:///tmp/build/80754af9/lazy-object-proxy_1616526917483/work
-libarchive-c @ file:///tmp/build/80754af9/python-libarchive-c_1617780486945/work
-llvmlite==0.36.0
-locket==0.2.1
-lxml @ file:///tmp/build/80754af9/lxml_1616443220220/work
--e git+https://github.com/lyft/nuscenes-devkit.git@8b55159e89d6318f143bd44dbdfde99ad7ff72e8#egg=lyft_dataset_sdk
-MarkupSafe==1.1.1
-matplotlib @ file:///tmp/build/80754af9/matplotlib-suite_1613407855456/work
+attrs==21.4.0
+black==22.1.0
+cachetools==5.0.0
+click==8.0.3
+cycler==0.11.0
+fire==0.4.0
+flake8==4.0.1
+fonttools==4.29.1
+iniconfig==1.1.1
+joblib==1.1.0
+kiwisolver==1.3.2
+-e git+ssh://git@github.com/stanford-futuredata/loa.git@73240c74c5df8f40fa7156231a2166f1d74f9408#egg=loa
+-e git+ssh://git@github.com/lyft/nuscenes-devkit.git@49c36da0a85da6bc9e8f2a39d5d967311cd75069#egg=lyft_dataset_sdk
+matplotlib==3.5.1
 mccabe==0.6.1
-mistune==0.8.4
-mkl-fft==1.3.0
-mkl-random @ file:///tmp/build/80754af9/mkl_random_1618853849286/work
-mkl-service==2.3.0
-mock @ file:///tmp/build/80754af9/mock_1607622725907/work
--e git+https://github.com/stanford-futuredata/omg.git@123c267d3d9b5818e0b510b7bcf4f0b1ab5c1047#egg=model_assertions
-more-itertools @ file:///tmp/build/80754af9/more-itertools_1613676688952/work
-mp4file==0.2
-mpmath==1.2.1
-msgpack @ file:///tmp/build/80754af9/msgpack-python_1612287151062/work
-multidict==6.0.2
-multipledispatch==0.6.0
 mypy-extensions==0.4.3
-nbclassic @ file:///tmp/build/80754af9/nbclassic_1616085367084/work
-nbclient @ file:///tmp/build/80754af9/nbclient_1614364831625/work
-nbconvert @ file:///tmp/build/80754af9/nbconvert_1601914830498/work
-nbformat @ file:///tmp/build/80754af9/nbformat_1617383369282/work
-nest-asyncio @ file:///tmp/build/80754af9/nest-asyncio_1613680548246/work
-networkx @ file:///tmp/build/80754af9/networkx_1594377231366/work
-nltk @ file:///tmp/build/80754af9/nltk_1618327084230/work
-nose @ file:///tmp/build/80754af9/nose_1606773131901/work
-notebook @ file:///tmp/build/80754af9/notebook_1616443462982/work
-numba @ file:///tmp/build/80754af9/numba_1616774046117/work
-numexpr @ file:///tmp/build/80754af9/numexpr_1618856167419/work
-numpy @ file:///tmp/build/80754af9/numpy_and_numpy_base_1618497241363/work
-numpydoc @ file:///tmp/build/80754af9/numpydoc_1605117425582/work
-olefile==0.46
-opencv-python==4.4.0.42
-openpyxl @ file:///tmp/build/80754af9/openpyxl_1615411699337/work
-packaging @ file:///tmp/build/80754af9/packaging_1611952188834/work
-pandas==1.2.4
-pandocfilters @ file:///tmp/build/80754af9/pandocfilters_1605120460739/work
-parso==0.7.0
-partd @ file:///tmp/build/80754af9/partd_1618000087440/work
-path @ file:///tmp/build/80754af9/path_1614022220526/work
-pathlib2 @ file:///tmp/build/80754af9/pathlib2_1607024983162/work
-pathspec==0.8.0
-pathtools==0.1.2
-patsy==0.5.1
-pep8==1.7.1
-pexpect @ file:///tmp/build/80754af9/pexpect_1605563209008/work
-pickleshare @ file:///tmp/build/80754af9/pickleshare_1606932040724/work
-Pillow @ file:///tmp/build/80754af9/pillow_1617383569452/work
-pkginfo==1.7.0
-plotly @ file:///tmp/build/80754af9/plotly_1610565580232/work
-pluggy @ file:///tmp/build/80754af9/pluggy_1615976321666/work
-ply==3.11
-prometheus-client @ file:///tmp/build/80754af9/prometheus_client_1618088486455/work
-promise @ file:///home/conda/feedstock_root/build_artifacts/promise_1636078143998/work
-prompt-toolkit @ file:///tmp/build/80754af9/prompt-toolkit_1616415428029/work
-psutil @ file:///tmp/build/80754af9/psutil_1612298023621/work
-ptyprocess @ file:///tmp/build/80754af9/ptyprocess_1609355006118/work/dist/ptyprocess-0.7.0-py2.py3-none-any.whl
-py @ file:///tmp/build/80754af9/py_1607971587848/work
-pyarrow==3.0.0
-pyasn1==0.4.8
-pycares==4.1.2
-pyclipper==1.1.0.post1
-pycodestyle @ file:///home/ktietz/src/ci_mi/pycodestyle_1612807597675/work
-pycosat==0.6.3
-pycparser @ file:///tmp/build/80754af9/pycparser_1594388511720/work
-pycurl==7.43.0.6
-pydocstyle @ file:///tmp/build/80754af9/pydocstyle_1616182067796/work
-pyerfa @ file:///tmp/build/80754af9/pyerfa_1619390903914/work
-pyexifinfo==0.4.0
-pyflakes @ file:///home/ktietz/src/ci_ipy2/pyflakes_1612551159640/work
-Pygments @ file:///tmp/build/80754af9/pygments_1615143339740/work
-PyJWT==2.3.0
-pylint @ file:///tmp/build/80754af9/pylint_1617135829881/work
-pyodbc===4.0.0-unsupported
-pyOpenSSL @ file:///tmp/build/80754af9/pyopenssl_1608057966937/work
-pyparsing @ file:///home/linux1/recipes/ci/pyparsing_1610983426697/work
-pyquaternion==0.9.5
-pyrsistent @ file:///tmp/build/80754af9/pyrsistent_1600141720057/work
-PySocks @ file:///tmp/build/80754af9/pysocks_1605305779399/work
-pytest==6.2.3
-python-bitcoinlib==0.11.0
-python-dateutil @ file:///home/ktietz/src/ci/python-dateutil_1611928101742/work
-python-jsonrpc-server @ file:///tmp/build/80754af9/python-jsonrpc-server_1594397536060/work
-python-language-server @ file:///tmp/build/80754af9/python-language-server_1594161909948/work
-pytz @ file:///tmp/build/80754af9/pytz_1612215392582/work
-PyWavelets @ file:///tmp/build/80754af9/pywavelets_1601658317819/work
-pyxdg @ file:///tmp/build/80754af9/pyxdg_1603822279816/work
-PyYAML==5.4.1
-pyzmq==20.0.0
-QDarkStyle @ file:///tmp/build/80754af9/qdarkstyle_1617386714626/work
-QtAwesome @ file:///tmp/build/80754af9/qtawesome_1615991616277/work
-qtconsole @ file:///tmp/build/80754af9/qtconsole_1616775094278/work
-QtPy==1.9.0
-readme-renderer==29.0
-regex @ file:///tmp/build/80754af9/regex_1617569202463/work
-requests @ file:///tmp/build/80754af9/requests_1629994808627/work
-requests-toolbelt==0.9.1
-retrying==1.3.3
-rfc3986==1.5.0
-rope @ file:///tmp/build/80754af9/rope_1602264064449/work
-rsa @ file:///home/conda/feedstock_root/build_artifacts/rsa_1614171254180/work
-Rtree @ file:///tmp/build/80754af9/rtree_1618420845272/work
-ruamel-yaml-conda @ file:///tmp/build/80754af9/ruamel_yaml_1616016699510/work
-Rx==1.6.1
-s3transfer @ file:///home/conda/feedstock_root/build_artifacts/s3transfer_1626384238958/work
-scikit-image==0.18.1
-scikit-learn @ file:///tmp/build/80754af9/scikit-learn_1614446682169/work
-scipy @ file:///tmp/build/80754af9/scipy_1618855647378/work
-seaborn @ file:///tmp/build/80754af9/seaborn_1608578541026/work
-SecretStorage @ file:///tmp/build/80754af9/secretstorage_1614022784285/work
-selenium @ file:///home/conda/feedstock_root/build_artifacts/selenium_1602632393611/work
-Send2Trash @ file:///tmp/build/80754af9/send2trash_1607525499227/work
-Shapely==1.7.1
-simplegeneric==0.8.1
-singledispatch @ file:///tmp/build/80754af9/singledispatch_1614366001199/work
-sip==4.19.13
-six @ file:///tmp/build/80754af9/six_1605205327372/work
-sniffio @ file:///tmp/build/80754af9/sniffio_1614030475067/work
-snowballstemmer @ file:///tmp/build/80754af9/snowballstemmer_1611258885636/work
-sortedcollections @ file:///tmp/build/80754af9/sortedcollections_1611172717284/work
-sortedcontainers @ file:///tmp/build/80754af9/sortedcontainers_1606865132123/work
-soupsieve @ file:///tmp/build/80754af9/soupsieve_1616183228191/work
-Sphinx @ file:///tmp/build/80754af9/sphinx_1618217326527/work
-sphinxcontrib-applehelp @ file:///home/ktietz/src/ci/sphinxcontrib-applehelp_1611920841464/work
-sphinxcontrib-devhelp @ file:///home/ktietz/src/ci/sphinxcontrib-devhelp_1611920923094/work
-sphinxcontrib-htmlhelp @ file:///home/ktietz/src/ci/sphinxcontrib-htmlhelp_1611920974801/work
-sphinxcontrib-jsmath @ file:///home/ktietz/src/ci/sphinxcontrib-jsmath_1611920942228/work
-sphinxcontrib-qthelp @ file:///home/ktietz/src/ci/sphinxcontrib-qthelp_1611921055322/work
-sphinxcontrib-serializinghtml @ file:///home/ktietz/src/ci/sphinxcontrib-serializinghtml_1611920755253/work
-sphinxcontrib-websupport @ file:///tmp/build/80754af9/sphinxcontrib-websupport_1597081412696/work
-spyder @ file:///tmp/build/80754af9/spyder_1599056981321/work
-spyder-kernels @ file:///tmp/build/80754af9/spyder-kernels_1599056754858/work
-SQLAlchemy @ file:///tmp/build/80754af9/sqlalchemy_1618089170652/work
-sqlparse @ file:///tmp/build/80754af9/sqlparse_1602184451250/work
-statsmodels @ file:///tmp/build/80754af9/statsmodels_1614023746358/work
-sympy @ file:///tmp/build/80754af9/sympy_1618252284338/work
-tables==3.6.1
-tblib @ file:///tmp/build/80754af9/tblib_1597928476713/work
+numpy==1.22.1
+opencv-python==4.5.5.62
+packaging==21.3
+pandas==1.4.0
+pathspec==0.9.0
+Pillow==9.0.0
+platformdirs==2.4.1
+plotly==5.5.0
+pluggy==1.0.0
+py==1.11.0
+pyclipper==1.3.0.post2
+pycodestyle==2.8.0
+pyflakes==2.4.0
+pyparsing==3.0.7
+pyquaternion==0.9.9
+pytest==6.2.5
+python-dateutil==2.8.2
+pytz==2021.3
+scikit-learn==1.0.2
+scipy==1.7.3
+Shapely==1.8.0
+six==1.16.0
+tenacity==8.0.1
 termcolor==1.1.0
-terminado==0.9.4
-testpath @ file:///home/ktietz/src/ci/testpath_1611930608132/work
-threadpoolctl @ file:///tmp/tmp9twdgx9k/threadpoolctl-2.1.0-py3-none-any.whl
-tifffile==2020.10.1
-toml @ file:///tmp/build/80754af9/toml_1616166611790/work
-toolz @ file:///home/linux1/recipes/ci/toolz_1610987900194/work
-torch==1.6.0
-torchvision==0.7.0
-tornado @ file:///tmp/build/80754af9/tornado_1606942300299/work
-tqdm @ file:///tmp/build/80754af9/tqdm_1615925068909/work
-traitlets @ file:///home/ktietz/src/ci/traitlets_1611929699868/work
-twine==3.4.1
-typed-ast==1.4.1
-typing-extensions @ file:///home/ktietz/src/ci_mi/typing_extensions_1612808209620/work
-ujson==1.35
-unicodecsv==0.14.1
-urllib3 @ file:///tmp/build/80754af9/urllib3_1615837158687/work
-watchdog @ file:///tmp/build/80754af9/watchdog_1612471027849/work
-wcwidth @ file:///tmp/build/80754af9/wcwidth_1593447189090/work
-webencodings==0.5.1
-Werkzeug @ file:///home/ktietz/src/ci/werkzeug_1611932622770/work
-widgetsnbextension==3.5.1
-wrapt==1.12.1
-wurlitzer @ file:///tmp/build/80754af9/wurlitzer_1617224664226/work
-xlrd @ file:///tmp/build/80754af9/xlrd_1608072521494/work
-XlsxWriter @ file:///tmp/build/80754af9/xlsxwriter_1617224712951/work
-xlwt==1.3.0
-yapf @ file:///tmp/build/80754af9/yapf_1615749224965/work
-yarl==1.7.2
-zict==2.0.0
-zipp @ file:///tmp/build/80754af9/zipp_1615904174917/work
-zope.event==4.5.0
-zope.interface @ file:///tmp/build/80754af9/zope.interface_1616357211867/work
+threadpoolctl==3.1.0
+toml==0.10.2
+tomli==2.0.0
+tqdm==4.62.3
+typing_extensions==4.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ fonttools==4.29.1
 iniconfig==1.1.1
 joblib==1.1.0
 kiwisolver==1.3.2
--e git+ssh://git@github.com/stanford-futuredata/loa.git@73240c74c5df8f40fa7156231a2166f1d74f9408#egg=loa
+-e git+ssh://git@github.com/stanford-futuredata/loa.git@16468a95b60079d7c4683cb1680b6eba8f87ddc4#egg=loa
 -e git+ssh://git@github.com/lyft/nuscenes-devkit.git@49c36da0a85da6bc9e8f2a39d5d967311cd75069#egg=lyft_dataset_sdk
 matplotlib==3.5.1
 mccabe==0.6.1
@@ -41,5 +41,6 @@ termcolor==1.1.0
 threadpoolctl==3.1.0
 toml==0.10.2
 tomli==2.0.0
+torch==1.10.2
 tqdm==4.62.3
 typing_extensions==4.0.1


### PR DESCRIPTION
The previous `requirements.txt` included direct references and packages that are needed in the dependency tree. Pruned to make sure that the dev environment is cleaner and easier.

Tested with python 3.9.1. Ran setup with:
```
python -m venv env
source env/bin/activate
pip install -r requirements.txt
python examples/lyft_level5/learn_priors.py
python examples/lyft_level5/prior_lyft.py
```